### PR TITLE
Ignore clients disconnected from WebsocketServer

### DIFF
--- a/ypy_websocket/websocket_server.py
+++ b/ypy_websocket/websocket_server.py
@@ -103,7 +103,12 @@ class WebsocketServer:
                 await room.on_message(message)
             # forward messages to every other client
             for client in [c for c in room.clients if c != websocket]:
-                await client.send(message)
+                # clients may have disconnected but not yet removed from the room
+                # ignore them and continue forwarding to other clients
+                try:
+                    await client.send(message)
+                except Exception:
+                    pass
             # update our internal state
             update = await process_message(message, room.ydoc, websocket)
             if room.ystore and update:


### PR DESCRIPTION
@hbcarlos saw an error in the back-end showing a traceback pointing to [this line](https://github.com/y-crdt/ypy-websocket/blob/0fc7e794d977ba8afc50d9248657a7639799500e/ypy_websocket/websocket_server.py#L106).
We should continue forwarding messages to other clients when one of them disconnects.