### PR TITLE
Store metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ packages = find:
 python_requires = >=3.7
 
 install_requires =
-  y-py >=0.5.0,<0.6.0
+  y-py >=0.5.2,<0.6.0
   aiofiles >=0.8.0,<1
   aiosqlite >=0.17.0,<1
 

--- a/tests/test_ystore.py
+++ b/tests/test_ystore.py
@@ -1,0 +1,46 @@
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from ypy_websocket.ystore import SQLiteYStore, TempFileYStore
+
+
+class MetadataCallback:
+    def __init__(self):
+        self.i = 0
+
+    def __call__(self):
+        future = asyncio.Future()
+        future.set_result(bytes(self.i))
+        self.i += 1
+        return future
+
+
+class MyTempFileYStore(TempFileYStore):
+    prefix_dir = "test_temp_"
+
+
+class MySQLiteYStore(SQLiteYStore):
+    db_path = str(Path(tempfile.mkdtemp(prefix="test_sql_")) / "ystore.db")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("YStore", (MyTempFileYStore, MySQLiteYStore))
+async def test_file_ystore(YStore):
+    store_name = "my_store"
+    ystore = YStore(store_name, metadata_callback=MetadataCallback())
+    data = [b"foo", b"bar", b"baz"]
+    for d in data:
+        await ystore.write(d)
+
+    if YStore == MyTempFileYStore:
+        assert (Path(MyTempFileYStore.base_dir) / store_name).exists()
+    elif YStore == MySQLiteYStore:
+        assert Path(MySQLiteYStore.db_path).exists()
+    i = 0
+    async for d, m in ystore.read():
+        assert d == data[i]  # data
+        assert m == bytes(i)  # metadata
+        i += 1

--- a/ypy_websocket/ydoc.py
+++ b/ypy_websocket/ydoc.py
@@ -55,7 +55,7 @@ class Transaction:
     ):
         res = self.transaction.__exit__(exc_type, exc_value, exc_tb)
         if self.ydoc.initialized.is_set():
-            update = Y.encode_state_as_update(self.ydoc, self.state)
+            update = bytes(Y.encode_state_as_update(self.ydoc, self.state))
             message = create_update_message(update)
             self.update_queue.put_nowait(message)
         return res
@@ -68,7 +68,7 @@ async def process_message(message: bytes, ydoc: YDoc, websocket):
         msg = message[2:]
         if message_type == YMessageType.SYNC_STEP1:
             state = get_message(msg)
-            update = Y.encode_state_as_update(ydoc, state)
+            update = bytes(Y.encode_state_as_update(ydoc, state))
             reply = create_sync_step2_message(update)
             await websocket.send(reply)
         elif message_type in (
@@ -84,6 +84,6 @@ async def process_message(message: bytes, ydoc: YDoc, websocket):
 
 async def sync(ydoc: YDoc, websocket):
     await ydoc.initialized.wait()
-    state = Y.encode_state_vector(ydoc)
+    state = bytes(Y.encode_state_vector(ydoc))
     msg = create_sync_step1_message(state)
     await websocket.send(msg)

--- a/ypy_websocket/yutils.py
+++ b/ypy_websocket/yutils.py
@@ -1,5 +1,4 @@
 from enum import IntEnum
-from typing import List
 
 
 class YMessageType(IntEnum):
@@ -9,28 +8,28 @@ class YMessageType(IntEnum):
     SYNC_UPDATE = 2
 
 
-def write_var_uint(num: int) -> List[int]:
+def write_var_uint(num: int) -> bytes:
     res = []
     while num > 127:
-        res += [128 | (127 & num)]
+        res.append(128 | (127 & num))
         num >>= 7
-    res += [num]
-    return res
+    res.append(num)
+    return bytes(res)
 
 
-def create_message(data: List[int], msg_type: int) -> bytes:
-    return bytes([YMessageType.SYNC, msg_type] + write_var_uint(len(data)) + data)
+def create_message(data: bytes, msg_type: int) -> bytes:
+    return bytes([YMessageType.SYNC, msg_type]) + write_var_uint(len(data)) + data
 
 
-def create_sync_step1_message(data: List[int]) -> bytes:
+def create_sync_step1_message(data: bytes) -> bytes:
     return create_message(data, YMessageType.SYNC_STEP1)
 
 
-def create_sync_step2_message(data: List[int]) -> bytes:
+def create_sync_step2_message(data: bytes) -> bytes:
     return create_message(data, YMessageType.SYNC_STEP2)
 
 
-def create_update_message(data: List[int]) -> bytes:
+def create_update_message(data: bytes) -> bytes:
     return create_message(data, YMessageType.SYNC_UPDATE)
 
 


### PR DESCRIPTION
A YStore now accepts a `metadata_callback`, which is an async callable returning `bytes`. The `ystore.write(data)` method will automatically write metadata along with the data by awaiting `metadata_callback()`. The `ystore.read()` iterator will return `(data, metadata)` tuples.
Thus, this new YStore format is not compatible with the previous format, which didn't include metadata (I think this is not a big deal at this stage of development).
It is the responsibility of the user to encode/decode metadata to/from bytes.

Closes #25.