### PR TITLE
Update state and YStore, and broadcast to clients concurrently

### DIFF
--- a/ypy_websocket/__init__.py
+++ b/ypy_websocket/__init__.py
@@ -1,4 +1,5 @@
 from .websocket_provider import WebsocketProvider  # noqa
-from .websocket_server import WebsocketServer  # noqa
+from .websocket_server import WebsocketServer, YRoom  # noqa
+from .yutils import YMessageType  # noqa
 
 __version__ = "0.3.2"

--- a/ypy_websocket/websocket_provider.py
+++ b/ypy_websocket/websocket_provider.py
@@ -15,7 +15,7 @@ class WebsocketProvider:
     def __init__(self, ydoc: Y.YDoc, websocket, log=None):
         self._ydoc = ydoc
         self._websocket = websocket
-        self.log = log or logging
+        self.log = log or logging.getLogger(__name__)
         self._update_queue = asyncio.Queue()
         ydoc.observe_after_transaction(partial(put_updates, self._update_queue, ydoc))
         asyncio.create_task(self._run())

--- a/ypy_websocket/websocket_provider.py
+++ b/ypy_websocket/websocket_provider.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from functools import partial
 
 import y_py as Y
@@ -11,9 +12,10 @@ class WebsocketProvider:
     _ydoc: Y.YDoc
     _update_queue: asyncio.Queue
 
-    def __init__(self, ydoc: Y.YDoc, websocket):
+    def __init__(self, ydoc: Y.YDoc, websocket, log=None):
         self._ydoc = ydoc
         self._websocket = websocket
+        self.log = log or logging
         self._update_queue = asyncio.Queue()
         ydoc.observe_after_transaction(partial(put_updates, self._update_queue, ydoc))
         asyncio.create_task(self._run())
@@ -22,7 +24,7 @@ class WebsocketProvider:
         await sync(self._ydoc, self._websocket)
         send_task = asyncio.create_task(self._send())
         async for message in self._websocket:
-            await process_message(message, self._ydoc, self._websocket)
+            await process_message(message, self._ydoc, self._websocket, self.log)
         send_task.cancel()
 
     async def _send(self):

--- a/ypy_websocket/websocket_server.py
+++ b/ypy_websocket/websocket_server.py
@@ -120,7 +120,8 @@ class WebsocketServer:
             # update our internal state
             update = await process_message(message, room.ydoc, websocket)
             if room.ystore and update:
-                await room.ystore.write(update)
+                # update the Y store in the background to prevent slow filesystems from slowing down the server
+                asyncio.create_task(room.ystore.write(update))
         # remove this client
         room.clients = [c for c in room.clients if c != websocket]
         if self.auto_clean_rooms and not room.clients:

--- a/ypy_websocket/websocket_server.py
+++ b/ypy_websocket/websocket_server.py
@@ -71,7 +71,7 @@ class WebsocketServer:
     def __init__(self, rooms_ready: bool = True, auto_clean_rooms: bool = True, log=None):
         self.rooms_ready = rooms_ready
         self.auto_clean_rooms = auto_clean_rooms
-        self.log = log or logging
+        self.log = log or logging.getLogger(__name__)
         self.rooms = {}
 
     def get_room(self, path: str) -> YRoom:

--- a/ypy_websocket/yutils.py
+++ b/ypy_websocket/yutils.py
@@ -10,10 +10,7 @@ class YMessageType(IntEnum):
     AWARENESS = 1
 
     def raw_str(self) -> str:
-        if self == YMessageType.SYNC:
-            return "SYNC"
-        else:
-            return "AWARENESS"
+        return self.name
 
 
 class YSyncMessageType(IntEnum):
@@ -22,12 +19,7 @@ class YSyncMessageType(IntEnum):
     SYNC_UPDATE = 2
 
     def raw_str(self) -> str:
-        if self == YSyncMessageType.SYNC_STEP1:
-            return "SYNC_STEP1"
-        elif self == YSyncMessageType.SYNC_STEP2:
-            return "SYNC_STEP2"
-        else:
-            return "SYNC_UPDATE"
+        return self.name
 
 
 def write_var_uint(num: int) -> bytes:

--- a/ypy_websocket/yutils.py
+++ b/ypy_websocket/yutils.py
@@ -117,3 +117,9 @@ async def sync(ydoc: Y.YDoc, websocket):
     state = Y.encode_state_vector(ydoc)
     msg = create_sync_step1_message(state)
     await websocket.send(msg)
+
+
+async def update(message, room, websocket):
+    yupdate = await process_message(message, room.ydoc, websocket)
+    if room.ystore and yupdate:
+        await room.ystore.write(yupdate)


### PR DESCRIPTION
@ellisonbg It would be interesting to test this change and see if it solves [the issue](https://github.com/jupyter-server/jupyter_server_ydoc/issues/50) you mentioned about performances on NFS.
The problem I see with that, and I think you also talked about it, is that if we let the Y store be out-of-sync, then that will likely cause other issues, for instance if a user connects in the middle of a session - they will probably be out of sync too, and I don't know how it will behave.