### PR TITLE
Add document TTL for SQLiteYStore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,4 +131,3 @@ dmypy.json
 # test JS dependencies
 tests/node_modules
 tests/package-lock.json
-tests/yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,8 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# test JS dependencies
+tests/node_modules
+tests/package-lock.json
+tests/yarn.lock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,3 @@ def yjs_client(request):
     p = subprocess.Popen(["node", f"tests/yjs_client_{client_id}.js"])
     yield p
     p.kill()
-
-@pytest.fixture
-def yjs_sqlite_db_path():
-    return str(Path(tempfile.mkdtemp(prefix="test_sql_")) / "ystore.db")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
 import subprocess
-import tempfile
-from pathlib import Path
 
 import pytest
 from websockets import serve  # type: ignore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import subprocess
+import tempfile
+from pathlib import Path
 
 import pytest
 from websockets import serve  # type: ignore
@@ -23,3 +25,7 @@ def yjs_client(request):
     p = subprocess.Popen(["node", f"tests/yjs_client_{client_id}.js"])
     yield p
     p.kill()
+
+@pytest.fixture
+def yjs_sqlite_db_path():
+    return str(Path(tempfile.mkdtemp(prefix="test_sql_")) / "ystore.db")

--- a/tests/test_ystore.py
+++ b/tests/test_ystore.py
@@ -1,6 +1,10 @@
 import asyncio
+import aiosqlite
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
+import time
+import os
 
 import pytest
 
@@ -25,6 +29,9 @@ class MyTempFileYStore(TempFileYStore):
 class MySQLiteYStore(SQLiteYStore):
     db_path = str(Path(tempfile.mkdtemp(prefix="test_sql_")) / "ystore.db")
 
+    def __del__(self):
+        os.remove(self.db_path)
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("YStore", (MyTempFileYStore, MySQLiteYStore))
@@ -44,3 +51,28 @@ async def test_file_ystore(YStore):
         assert d == data[i]  # data
         assert m == bytes(i)  # metadata
         i += 1
+
+@pytest.mark.asyncio
+async def test_document_ttl_sqlite_ystore():
+    store_name = "my_store"
+    ystore = MySQLiteYStore(store_name, metadata_callback=MetadataCallback())
+
+    await ystore.write(b"a")
+    async with aiosqlite.connect(ystore.db_path) as db:
+        assert (await (await db.execute('SELECT count(*) FROM yupdates')).fetchone())[0] == 1
+
+    now = time.time()
+
+    # assert that adding a record before document TTL doesn't delete document history
+    with patch("time.time") as mock_time:
+        mock_time.return_value = now
+        await ystore.write(b"b")
+        async with aiosqlite.connect(ystore.db_path) as db:
+            assert (await (await db.execute('SELECT count(*) FROM yupdates')).fetchone())[0] == 2
+
+    # assert that adding a record after document TTL deletes previous document history
+    with patch("time.time") as mock_time:
+        mock_time.return_value = now + ystore.document_ttl + 1000
+        await ystore.write(b"c")
+        async with aiosqlite.connect(ystore.db_path) as db:
+            assert (await (await db.execute('SELECT count(*) FROM yupdates')).fetchone())[0] == 1

--- a/tests/test_ystore.py
+++ b/tests/test_ystore.py
@@ -1,11 +1,11 @@
 import asyncio
-import aiosqlite
+import os
 import tempfile
+import time
 from pathlib import Path
 from unittest.mock import patch
-import time
-import os
 
+import aiosqlite
 import pytest
 
 from ypy_websocket.ystore import SQLiteYStore, TempFileYStore
@@ -52,6 +52,7 @@ async def test_file_ystore(YStore):
         assert m == bytes(i)  # metadata
         i += 1
 
+
 @pytest.mark.asyncio
 async def test_document_ttl_sqlite_ystore():
     store_name = "my_store"
@@ -59,7 +60,7 @@ async def test_document_ttl_sqlite_ystore():
 
     await ystore.write(b"a")
     async with aiosqlite.connect(ystore.db_path) as db:
-        assert (await (await db.execute('SELECT count(*) FROM yupdates')).fetchone())[0] == 1
+        assert (await (await db.execute("SELECT count(*) FROM yupdates")).fetchone())[0] == 1
 
     now = time.time()
 
@@ -68,11 +69,11 @@ async def test_document_ttl_sqlite_ystore():
         mock_time.return_value = now
         await ystore.write(b"b")
         async with aiosqlite.connect(ystore.db_path) as db:
-            assert (await (await db.execute('SELECT count(*) FROM yupdates')).fetchone())[0] == 2
+            assert (await (await db.execute("SELECT count(*) FROM yupdates")).fetchone())[0] == 2
 
     # assert that adding a record after document TTL deletes previous document history
     with patch("time.time") as mock_time:
         mock_time.return_value = now + ystore.document_ttl + 1000
         await ystore.write(b"c")
         async with aiosqlite.connect(ystore.db_path) as db:
-            assert (await (await db.execute('SELECT count(*) FROM yupdates')).fetchone())[0] == 1
+            assert (await (await db.execute("SELECT count(*) FROM yupdates")).fetchone())[0] == 1

--- a/ypy_websocket/ystore.py
+++ b/ypy_websocket/ystore.py
@@ -173,7 +173,7 @@ class SQLiteYStore(BaseYStore):
             # first, determine time elapsed since last update
             cursor = await db.execute(
                 "SELECT timestamp FROM yupdates WHERE path = ? ORDER BY timestamp DESC LIMIT 1",
-                (self.path,)
+                (self.path,),
             )
             row = await cursor.fetchone()
             diff = (time.time() - row[0]) if row else 0


### PR DESCRIPTION
Right now, the SQLite database storing document updates continues to grows without bound as users edit files. We store all document updates because users may briefly lose connection during a session and our backend needs to deliver all the patches they missed during that interval.

However, we can be reasonably confident that if a document has not been updated after some duration of time (let's say 24 hours), then there are no users still editing that file. When this happens, we can safely delete the patches for that file, as the current contents are already persisted to disk. We term this interval the "time to live" (TTL), because the document updates will only be kept alive (i.e. persisted) if the last update was within the TTL.

This PR adds a class attribute (which we will probably want to make configurable later via traitlets) that stores the TTL for every document to SQLiteYStore, and checks this before every write to determine if we should delete all the previous document updates associated with this path. Adds a unit test covering both the pre-TTL and post-TTL cases.