### PR TITLE
use 127.0.0.1 instead of localhost

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ async def yws_server(request):
     except Exception:
         kwargs = {}
     websocket_server = WebsocketServer(**kwargs)
-    async with serve(websocket_server.serve, "localhost", 1234):
+    async with serve(websocket_server.serve, "127.0.0.1", 1234):
         yield websocket_server
 
 

--- a/tests/test_ypy_yjs.py
+++ b/tests/test_ypy_yjs.py
@@ -39,7 +39,7 @@ class YTest:
 async def test_ypy_yjs_0(yws_server, yjs_client):
     ydoc = Y.YDoc()
     ytest = YTest(ydoc)
-    websocket = await connect("ws://localhost:1234/my-roomname")
+    websocket = await connect("ws://127.0.0.1:1234/my-roomname")
     WebsocketProvider(ydoc, websocket)
     ymap = ydoc.get_map("map")
     # set a value in "in"

--- a/tests/yjs_client_0.js
+++ b/tests/yjs_client_0.js
@@ -7,7 +7,7 @@ const ymap = ydoc.getMap('map')
 const ws = require('ws')
 
 const wsProvider = new WebsocketProvider(
-  'ws://localhost:1234', 'my-roomname',
+  'ws://127.0.0.1:1234', 'my-roomname',
   ydoc,
   { WebSocketPolyfill: ws }
 )

--- a/tests/yjs_client_1.js
+++ b/tests/yjs_client_1.js
@@ -8,7 +8,7 @@ const ystate = ydoc.getMap("state")
 const ws = require('ws')
 
 const wsProvider = new WebsocketProvider(
-  'ws://localhost:1234', 'my-roomname',
+  'ws://127.0.0.1:1234', 'my-roomname',
   ydoc,
   { WebSocketPolyfill: ws }
 )


### PR DESCRIPTION
Hi, thanks for `ypy-websocket`.

When testing downstream (e.g in https://github.com/conda-forge/ypy-websocket-feedstock/pull/21), docker containers can get confused with the `localhost` string (perhaps some IPv6 thing?). `127.0.0.1` seems to be more reliable.