### PR TITLE
include tests in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ path = "ypy_websocket/__init__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/ypy_websocket",
+    "/tests",
 ]
 
 [tool.flake8]


### PR DESCRIPTION
Thanks again for `ypy-websocket`.

It would be lovely for downstreams (e.g. https://github.com/conda-forge/ypy-websocket-feedstock/pull/21) if the tests were available in the canonical source distribution.

As the tests include a `nodejs` component, further including a `package-lock.json` (and/or a `yarn.lock`) would be useful for reducing the variability of the test environment.