### PR TITLE
squash doc history in separate task

### DIFF
--- a/ypy_websocket/ystore.py
+++ b/ypy_websocket/ystore.py
@@ -177,6 +177,7 @@ class SQLiteYStore(BaseYStore):
         self.metadata_callback = metadata_callback
         self.log = log or logging.getLogger(__name__)
         self.db_initialized = asyncio.create_task(self.init_db())
+        self._squash_task: Optional[asyncio.Task] = None
 
     async def init_db(self):
         create_db = False
@@ -231,36 +232,44 @@ class SQLiteYStore(BaseYStore):
     async def write(self, data: bytes) -> None:
         await self.db_initialized
         async with aiosqlite.connect(self.db_path) as db:
-            # first, determine time elapsed since last update
-            cursor = await db.execute(
-                "SELECT timestamp FROM yupdates WHERE path = ? ORDER BY timestamp DESC LIMIT 1",
-                (self.path,),
-            )
-            row = await cursor.fetchone()
-            diff = (time.time() - row[0]) if row else 0
-
-            if self.document_ttl is not None and diff > self.document_ttl:
-                # squash updates
-                ydoc = Y.YDoc()
-                async with db.execute(
-                    "SELECT yupdate FROM yupdates WHERE path = ?", (self.path,)
-                ) as cursor:
-                    async for update, in cursor:
-                        Y.apply_update(ydoc, update)
-                # delete history
-                await db.execute("DELETE FROM yupdates WHERE path = ?", (self.path,))
-                # insert squashed updates
-                squashed_update = Y.encode_state_as_update(ydoc)
-                metadata = await self.get_metadata()
-                await db.execute(
-                    "INSERT INTO yupdates VALUES (?, ?, ?, ?)",
-                    (self.path, squashed_update, metadata, time.time()),
-                )
-
-            # finally, write this update to the DB
+            # write this update to the DB
             metadata = await self.get_metadata()
             await db.execute(
                 "INSERT INTO yupdates VALUES (?, ?, ?, ?)",
                 (self.path, data, metadata, time.time()),
             )
             await db.commit()
+        # create task that squashes document history after document_ttl
+        self._create_squash_task()
+
+    async def _squash_coroutine(self):
+        await asyncio.sleep(self.document_ttl)
+        async with aiosqlite.connect(self.db_path) as db:
+            # squash updates
+            ydoc = Y.YDoc()
+            async with db.execute(
+                "SELECT yupdate FROM yupdates WHERE path = ?", (self.path,)
+            ) as cursor:
+                async for update, in cursor:
+                    Y.apply_update(ydoc, update)
+            # delete history
+            await db.execute("DELETE FROM yupdates WHERE path = ?", (self.path,))
+            # insert squashed updates
+            squashed_update = Y.encode_state_as_update(ydoc)
+            metadata = await self.get_metadata()
+            await db.execute(
+                "INSERT INTO yupdates VALUES (?, ?, ?, ?)",
+                (self.path, squashed_update, metadata, time.time()),
+            )
+            await db.commit()
+
+    def _create_squash_task(self) -> None:
+        """Creates a task that squashes document history after self.document_ttl
+        and binds it to the _squash_task attribute. If a task already exists,
+        this cancels the existing task."""
+        if self.document_ttl is None:
+            return
+        if self._squash_task is not None:
+            self._squash_task.cancel()
+
+        self._squash_task = asyncio.create_task(self._squash_coroutine())


### PR DESCRIPTION
Squashes document history in a separate scheduled task rather than on write. This will significantly improve performance for document writes in the case where the time since last update exceeds the document TTL.

## Open concerns

- Is there any good way of stubbing out `asyncio.sleep()` in the unit tests? Testing this is tricky because it's not as simple as doing `unittest.mock.patch("asyncio.sleep")`, since that causes the document history to be squashed on every write. What I'm looking for is a utility that lets me imperatively advance the event loop clock, e.g. `loop.advance(123)`. I found [asynctest](https://github.com/Martiusweb/asynctest), but it doesn't seem to work and is abandoned.

