### PR TITLE
Compare dicts not JSON string with dicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
 dependencies = [
     "aiofiles >=22.1.0,<23",
     "aiosqlite >=0.17.0,<1",
-    "y-py >=0.5.3,<0.6.0",
+    "y-py >=0.5.8,<0.6.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_ypy_yjs.py
+++ b/tests/test_ypy_yjs.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 
 import pytest
 import y_py as Y
@@ -70,5 +71,5 @@ async def test_ypy_yjs_1(yws_server, yjs_client):
     await ytest.clock_run()
     ycells = ydoc.get_array("cells")
     ystate = ydoc.get_map("state")
-    assert ycells.to_json() == [{"metadata": {"foo": "bar"}, "source": "1 + 2"}]
-    assert ystate.to_json() == {"state": {"dirty": False}}
+    assert json.loads(ycells.to_json()) == [{"metadata": {"foo": "bar"}, "source": "1 + 2"}]
+    assert json.loads(ystate.to_json()) == {"state": {"dirty": False}}


### PR DESCRIPTION
The test fails for me otherwise. `YArray().to_json()` produces a string, which cannot be compared to a list of dicts or dict.

```python
[    6s] =================================== FAILURES ===================================
[    6s] ______________________________ test_ypy_yjs_1[1] _______________________________
[    6s] 
[    6s] yws_server = <ypy_websocket.websocket_server.WebsocketServer object at 0x7f97d5a6eb20>
[    6s] yjs_client = <subprocess.Popen object at 0x7f97d5ac3e50>
[    6s] 
[    6s]     @pytest.mark.asyncio
[    6s]     @pytest.mark.parametrize("yjs_client", "1", indirect=True)
[    6s]     async def test_ypy_yjs_1(yws_server, yjs_client):
[    6s]         # wait for the JS client to connect
[    6s]         tt, dt = 0, 0.1
[    6s]         while True:
[    6s]             await asyncio.sleep(dt)
[    6s]             if "/my-roomname" in yws_server.rooms:
[    6s]                 break
[    6s]             tt += dt
[    6s]             if tt >= 1:
[    6s]                 raise RuntimeError("Timeout waiting for client to connect")
[    6s]         ydoc = yws_server.rooms["/my-roomname"].ydoc
[    6s]         ytest = YTest(ydoc)
[    6s]         ytest.run_clock()
[    6s]         await ytest.clock_run()
[    6s]         ycells = ydoc.get_array("cells")
[    6s]         ystate = ydoc.get_map("state")
[    6s] >       assert ycells.to_json() == [{"metadata": {"foo": "bar"}, "source": "1 + 2"}]
[    6s] E       assert '[{"source":"1 + 2","metadata":{"foo":"bar"}}]' == [{'metadata': {'foo': 'bar'}, 'source': '1 + 2'}]
[    6s] E        +  where '[{"source":"1 + 2","metadata":{"foo":"bar"}}]' = <built-in method to_json of builtins.YArray object at 0x7f97d59c15b0>()
[    6s] E        +    where <built-in method to_json of builtins.YArray object at 0x7f97d59c15b0> = YArray([{'metadata': {'foo': 'bar'}, 'source': '1 + 2'}]).to_json
[    6s] 
[    6s] tests/test_ypy_yjs.py:73: AssertionError
```

Note that comparing the `.to_json()` output to a hardcoded string literal fails unpredictably because the dict key order is not stable.