### PR TITLE
Move pytest.ini entries to pyproject.toml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,16 +39,15 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Install Miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: actions/checkout@v3
+      - name: Install mamba
+        uses: mamba-org/provision-with-micromamba@main
         with:
-          mamba-version: "*"
-          channels: conda-forge
-          python-version: "3.7"
+          environment-file: environment-dev.yml
+          environment-name: ypy-websocket
+          extra-specs: python=${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          mamba install python=${{ matrix.python-version }} pip nodejs
           pip install .[test]
           cd tests; npm install
       - name: Check types

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         args: ["--line-length", "100"]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         files: \.py$

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,0 +1,6 @@
+name: ypy-websocket
+channels:
+  - conda-forge
+dependencies:
+  - pip
+  - nodejs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,6 @@ extend-ignore = [
     # black adds spaces around ':'
     "E203",
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ name = "ypy-websocket"
 dynamic = ["version"]
 description = "WebSocket connector for Ypy"
 readme = "README.md"
-license = "MIT"
 requires-python = ">=3.7"
 authors = [
     { name = "David Brochart", email = "david.brochart@gmail.com" },

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-asyncio_mode = auto


### PR DESCRIPTION
Avoids errors like #62 because pytest.ini is not in the sdist