### PR TITLE
Keep reference to asyncio tasks

### DIFF
--- a/ypy_websocket/websocket_provider.py
+++ b/ypy_websocket/websocket_provider.py
@@ -24,7 +24,7 @@ class WebsocketProvider:
         self.log = log or logging.getLogger(__name__)
         self._update_queue = asyncio.Queue()
         ydoc.observe_after_transaction(partial(put_updates, self._update_queue, ydoc))
-        asyncio.create_task(self._run())
+        self._run_task = asyncio.create_task(self._run())
 
     async def _run(self):
         await sync(self._ydoc, self._websocket, self.log)


### PR DESCRIPTION
A reference to the result of `asyncio.create_task()` should be kept, to avoid a task disappearing mid-execution. See [the documentation](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task):
![image](https://user-images.githubusercontent.com/4711805/220374173-2ce8ad64-ba8f-4aa5-ac46-96ca0556ef44.png)