### PR TITLE
Add a way to listen on next synchronization

### DIFF
--- a/docs/usage/client.md
+++ b/docs/usage/client.md
@@ -11,12 +11,17 @@ async def client():
     ydoc = Y.YDoc()
     async with (
         connect("ws://localhost:1234/my-roomname") as websocket,
-        WebsocketProvider(ydoc, websocket),
+        WebsocketProvider(ydoc, websocket) as provider,
     ):
+        ymap = ydoc.get_map("map")
+        
+        # Wait until we've received the initial state from the server.
+        await provider.synced.wait()
+        print(ymap.to_json())
+
         # Changes to remote ydoc are applied to local ydoc.
         # Changes to local ydoc are sent over the WebSocket and
         # broadcast to all clients.
-        ymap = ydoc.get_map("map")
         with ydoc.begin_transaction() as t:
             ymap.set(t, "key", "value")
 

--- a/ypy_websocket/websocket_provider.py
+++ b/ypy_websocket/websocket_provider.py
@@ -111,6 +111,7 @@ class WebsocketProvider:
                 await process_sync_message(message[1:], self._ydoc, self._websocket, self.log)
                 if self._synced is not None:
                     self._synced.set()
+                    self._synced = None
 
     async def _send(self):
         async with self._update_receive_stream:


### PR DESCRIPTION
I wanted a clean way to wait for the initial data to be synchronized down to the client, similar to `y-websocket`'s `.on('sync')` ([docs](https://github.com/yjs/y-websocket/blob/05b2f894d5237005b70a3d3ab01f040111371506/README.md?plain=1#L97-L98)), except that to be consistent with `started(self)`, it uses an `anyio.Event` instead of a callback function.

Calling `await provider.synced.wait()` will resolve when the _next_ synchronization message from the server is received and processed.

I'm not deep into async Python stuff -- I _think_ this is a reasonable way to do this, but if there's another approach you'd prefer I'd be glad to update the PR.